### PR TITLE
fix: buidl#680 deposit preview and simulation error handling

### DIFF
--- a/src/components/PoolAdd/index.tsx
+++ b/src/components/PoolAdd/index.tsx
@@ -1083,16 +1083,7 @@ const Swap = () => {
             //   Number(toAmount.replace(/,/g, "")) * 10 ** token2.decimals
             // ),
           ]
-        : [
-            toAmountBI,
-            fromAmountBI,
-            Math.round(
-              Number(toAmount.replace(/,/g, "")) * 10 ** token.decimals
-            ),
-            Math.round(
-              Number(fromAmount.replace(/,/g, "")) * 10 ** token2.decimals
-            ),
-          ],
+        : [toAmountBI, fromAmountBI],
       0
     ).then((Provider_depositR: any) => {
       if (Provider_depositR.success) {
@@ -1744,7 +1735,20 @@ const Swap = () => {
       console.log("swapR", swapR);
 
       if (!swapR.success) {
-        return new Error("Add liquidity group simulation failed");
+        const err = swapR as unknown as { message?: unknown; error?: unknown };
+        const detail =
+          typeof err.error === "string"
+            ? err.error
+            : err.error != null
+              ? String(err.error)
+              : typeof err.message === "string"
+                ? err.message
+                : "";
+        throw new Error(
+          detail
+            ? `Add liquidity group simulation failed: ${detail}`
+            : "Add liquidity group simulation failed"
+        );
       }
 
       setProgress(50);

--- a/src/components/PoolRemove/index.tsx
+++ b/src/components/PoolRemove/index.tsx
@@ -698,7 +698,7 @@ const PoolRemove = () => {
       const arc200_balanceOfR = await ci.arc200_balanceOf(
         activeAccount.address
       );
-      if (!arc200_balanceOfR.success) return new Error("Balance failed");
+      if (!arc200_balanceOfR.success) throw new Error("Balance failed");
       const poolShare = arc200_balanceOfR.returnValue;
 
       const withdrawAmount =
@@ -717,7 +717,7 @@ const PoolRemove = () => {
         [0, 0]
       );
       if (!Provider_withdrawR.success)
-        return new Error("Add liquidity simulation failed");
+        throw new Error("Withdraw preview simulation failed");
       const Provider_withdraw = Provider_withdrawR.returnValue;
 
       console.log({
@@ -887,7 +887,7 @@ const PoolRemove = () => {
       const customR = await ci.custom();
       console.log({ customR });
       if (!customR.success)
-        return new Error("Remove liquidity group simulation failed");
+        throw new Error("Remove liquidity group simulation failed");
 
       const stxns = await signTransactions(
         customR.txns.map(


### PR DESCRIPTION
## Summary
Addresses **[buidl#680] Deposit issues** in `humble-interface` (branch from `beta`).

## Root cause
1. **`Provider_deposit` preview** — The Reach/ABI shape is `Provider_deposit(byte,(uint256,uint256),uint256)`. When the user’s first token is **not** pool token A (`swapAForB === false`), the code passed **four** numeric values in the tuple slot instead of two (two stray `Math.round` amounts). That corrupts the contract call used for expected LP / share preview whenever token order is B-first.
2. **Add liquidity simulation** — On `!swapR.success`, the handler used `return new Error(...)` instead of `throw`, so execution continued into signing/sending despite a failed simulation (misleading failures or unsafe follow-on).
3. **Pool remove (related)** — The same `return new Error` anti-pattern existed on remove-liquidity paths; replaced with `throw` so failures surface in the catch/toast and do not fall through.

## Testing
- `npx tsc -b` passes locally.

## Notes
- GitHub issue #680 was not visible on this repo via `gh issue view`; buidl reference kept in title/body per task tracking.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of expected outcome calculations in pool addition operations
  * Enhanced error messages to display detailed information when liquidity operations fail
  * Fixed error handling in pool removal operations to reliably prevent failed transactions from proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->